### PR TITLE
Add interview_reminder command

### DIFF
--- a/otter_buddy/cogs/interview_reminder.py
+++ b/otter_buddy/cogs/interview_reminder.py
@@ -1,0 +1,94 @@
+import random
+import discord
+import asyncio
+import logging
+import datetime
+
+from discord.ext import commands
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from otter_buddy.utils.db import db_email, db_interview_reminder
+from otter_buddy.utils.email.emailconn import EmailConn
+from otter_buddy.utils.common import create_match_image
+from otter_buddy.constants import OTTER_ADMIN, OTTER_MODERATOR, OTTER_ROLE
+
+logger = logging.getLogger(__name__)
+
+
+class InterviewReminder(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.scheduler: AsyncIOScheduler = AsyncIOScheduler()
+        self.emoji: str = '👍'
+        self.channel: discord.TextChannel = None
+        self.message: discord.TextChannel = None
+        self.author: discord.User = None
+        self.guild: discord.Guild = None
+
+        self.scheduler.add_job(self.send_scheduled_message, CronTrigger(hour=12, timezone="America/Mexico_City"))
+        self.scheduler.start()
+
+    @commands.group(brief='Commands related to set reminders for interviews!', invoke_without_command=True)
+    async def interview_reminder(self, ctx, *, content:str):
+        '''
+        Interview Reminder will help to keep people aware of your activities.
+        '''
+        await ctx.send_help(ctx.command)
+
+    async def send_scheduled_message(self):
+        weekday = datetime.datetime.today().weekday()
+        for entry in db_interview_reminder.DbInterviewReminder.get_day_interview_reminder(weekday):
+            try:
+                guild = next(guild for guild in self.bot.guilds if guild.id == entry["guild_id"])
+            except StopIteration:
+                logger.error(f"Not guild found in {__name__}")
+            except Exception as e:
+                logger.error(f"Exception in {__name__}")
+                logger.error(e)
+            finally:
+                reminder_message: str = (
+                    f'{entry["role_mention"]}\n'
+                    f'{entry["message"]}'
+                )
+                channel = self.bot.get_channel(entry["channel_id"])
+                await channel.send(reminder_message)
+
+    @interview_reminder.command(brief='Start interview reminder', usage='<text_channel> [message_id] [role] [day_of_week]')
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def start(self, ctx, channel: discord.TextChannel, message_id: int, role: discord.Role = None, day_of_week: int = None):
+        '''
+        Start Interview Reminder setting up options, use the message id to refer the template that will be sent each time \
+        (keep in mind that this message need to be in the same channel where you're invoking this command). The channel, \
+        role and day of the week is configuration about how to send the reminder.
+        '''
+        cache_message = await ctx.fetch_message(message_id)
+        
+        interview_reminder = {
+            "day_of_the_week":  5 if day_of_week is None else day_of_week % 7,
+            "channel_id":       channel.id,
+            "role_mention":     '' if role is None else role.mention,
+            "message":          cache_message.content,
+            "guild_id":         ctx.guild.id,
+        }
+
+        db_interview_reminder.DbInterviewReminder.set_interview_reminder(interview_reminder)
+
+        await ctx.send(f"**Interview Reminder** scheduled! Let me do the boring job.")
+
+    @interview_reminder.command(brief='Stop interview match activity')
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def stop(self, ctx):
+        '''
+        Stop Interview Reminder
+        '''
+        result = db_interview_reminder.DbInterviewReminder.delete_interview_reminder(ctx.guild.id)
+        msg: str = ""
+        if result.deleted_count == 1:
+            msg = "**Interview Reminder** activity stopped!"
+        else:
+            msg = "No reminder was set! 😱"
+        await ctx.send(msg)
+
+def setup(bot):
+    bot.add_cog(InterviewReminder(bot))

--- a/otter_buddy/utils/db/db_interview_reminder.py
+++ b/otter_buddy/utils/db/db_interview_reminder.py
@@ -1,0 +1,30 @@
+import pymongo
+
+from otter_buddy.utils.db.dbconn import DbConn
+
+
+class DbInterviewReminder:
+
+    @staticmethod
+    def get_interview_reminder(guild_id: int):
+        with DbConn() as conn:
+            result = conn.connection.OtterBuddy.interview_reminders.find_one({ "guild_id": guild_id })
+            return result
+
+    @staticmethod
+    def get_day_interview_reminder(weekday: int):
+        with DbConn() as conn:
+            result = conn.connection.OtterBuddy.interview_reminders.find({ "day_of_the_week": weekday })
+            return result
+
+    @staticmethod
+    def set_interview_reminder(interview_reminder):
+        with DbConn() as conn:
+            result = conn.connection.OtterBuddy.interview_reminders.update_one({ "guild_id" : { "$eq": interview_reminder['guild_id'] } }, { "$set" : interview_reminder }, upsert=True)
+            return result
+
+    @staticmethod
+    def delete_interview_reminder(guild_id: int):
+        with DbConn() as conn:
+            result = conn.connection.OtterBuddy.interview_reminders.delete_one({ "guild_id" : { "$eq": guild_id } })
+            return result

--- a/tests/test_discord/test_interview_reminder.py
+++ b/tests/test_discord/test_interview_reminder.py
@@ -1,0 +1,111 @@
+import datetime
+
+import discord
+import discord.ext.test as dpytest
+import pytest
+import mongomock
+from unittest.mock import patch
+
+from otter_buddy import constants
+from otter_buddy.cogs import interview_reminder
+from otter_buddy.utils.db import dbconn, db_interview_reminder
+
+
+mock_connection = mongomock.MongoClient('mongodb://localhost:27021')
+
+def mock_client(self):
+    self.connection = mock_connection
+    return self
+
+@pytest.fixture(autouse=True)
+def interview_reminder_cog(bot: discord.ext.commands.Bot):
+    interview_reminder_cog = interview_reminder.InterviewReminder(bot)
+    bot.add_cog(interview_reminder_cog)
+    dpytest.configure(bot, 2, 2, 2)
+    print("Tests starting")
+    return interview_reminder_cog
+
+
+# === TESTING ===
+
+@patch.object(dbconn.DbConn, '__enter__', mock_client)
+@pytest.mark.asyncio
+async def test_send_weekly_message(interview_reminder_cog):
+    config = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = config.channels[0]
+    role_name: str = 'TEST_ROLE'
+    role: discord.Role = dpytest.backend.make_role(name=role_name, guild=guild)
+    dpytest.backend.update_guild(guild=guild, roles=guild.roles.extend([role]))
+    message: str = 'This is a test reminder'
+
+    interview_reminder = {
+        "day_of_the_week":  datetime.datetime.today().weekday(),
+        "channel_id":       channel.id,
+        "role_mention":     role.mention,
+        "message":          message,
+        "guild_id":         guild.id,
+    }
+    db_interview_reminder.DbInterviewReminder.set_interview_reminder(interview_reminder)
+
+    await interview_reminder_cog.send_scheduled_message()
+
+    expected: str = (
+        f'{role.mention}\n'
+        f'{message}'
+    )
+    assert dpytest.verify().message().content(expected)
+
+    db_interview_reminder.DbInterviewReminder.delete_interview_reminder(guild.id)
+
+@patch.object(dbconn.DbConn, '__enter__', mock_client)
+@pytest.mark.asyncio
+async def test_succesfully_stop(interview_reminder_cog):
+    config = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = config.channels[0]
+    role_name: str = constants.OTTER_ADMIN
+    role: discord.Role = dpytest.backend.make_role(name=role_name, guild=guild)
+    dpytest.backend.update_guild(guild=guild, roles=guild.roles.extend([role]))
+    message: str = 'This is a test reminder'
+
+    interview_reminder = {
+        "day_of_the_week":  datetime.datetime.today().weekday(),
+        "channel_id":       channel.id,
+        "role_mention":     role.mention,
+        "message":          message,
+        "guild_id":         guild.id,
+    }
+    db_interview_reminder.DbInterviewReminder.set_interview_reminder(interview_reminder)
+
+    result = db_interview_reminder.DbInterviewReminder.get_interview_reminder(guild.id)
+    assert result["guild_id"] == guild.id
+
+    user: discord.Member = config.members[0]
+    extended_roles = user.roles
+    extended_roles.append(role)
+    dpytest.backend.update_member(member=user, roles=extended_roles)
+    expected: str = "**Interview Reminder** activity stopped!"
+    await dpytest.message(f'{constants.PREFIX}interview_reminder stop', channel=channel, member=user)
+    assert dpytest.verify().message().content(expected)
+
+    result = db_interview_reminder.DbInterviewReminder.get_interview_reminder(guild.id)
+    assert result is None
+
+@patch.object(dbconn.DbConn, '__enter__', mock_client)
+@pytest.mark.asyncio
+async def test_unsuccesfully_stop(interview_reminder_cog):
+    config = dpytest.get_config()
+    user: discord.Member = config.members[0]
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = config.channels[0]
+    role_name: str = constants.OTTER_ADMIN
+    role: discord.Role = dpytest.backend.make_role(name=role_name, guild=guild)
+    extended_roles = user.roles
+    extended_roles.append(role)
+    dpytest.backend.update_guild(guild=guild, roles=guild.roles.extend([role]))
+    dpytest.backend.update_member(member=user, roles=extended_roles)
+
+    expected: str = "No reminder was set! 😱"
+    await dpytest.message(f'{constants.PREFIX}interview_reminder stop', channel=channel, member=user)
+    assert dpytest.verify().message().content(expected)


### PR DESCRIPTION
Add new command `interview_reminder`, with the following parameters:
* **channel**: where to send the message.
* **message_id**: reference to the *message template* that will be sent each time that the reminder is send.
* **role** (optional): discord role to mention. 
* **day_of_week** (optional, if not sent, is Friday): day where 0 is Sunday and 6 is Saturday where the reminder will be send.

![image](https://user-images.githubusercontent.com/26100917/133021302-adebaabf-5d64-4df2-9a8e-f0af71f59e55.png)

![image](https://user-images.githubusercontent.com/26100917/133021334-4088bc84-135e-4de1-b979-d284152abfe8.png)
